### PR TITLE
Add Profile for DeadlyReentry

### DIFF
--- a/GameData/DeadlyReentry/DeadlyReentry-Benjee10_shuttleOrbiter.cfg
+++ b/GameData/DeadlyReentry/DeadlyReentry-Benjee10_shuttleOrbiter.cfg
@@ -1,0 +1,14 @@
+@PART[benjee10_shuttle_forwardFuselage|benjee10_shuttle_midFuselage|benjee10_shuttle_deltaWing|benjee10_shuttle_elevon1|benjee10_shuttle_elevon2|benjee10_shuttle_bodyFlap|benjee10_shuttle_noseGear|benjee10_shuttle_mainGear]:FOR[DeadlyReentry]
+{
+	@maxTemp = 1800
+	%emissiveConstant = 0.85
+	%skinMaxTemp = 3100
+	%skinThermalMassModifier = 0.21
+	%skinInternalConductionMult = 0.000008
+	%skinMassPerArea = 0.33
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
+}


### PR DESCRIPTION
This profile allows [Shuttle-Orbiter-Construction-Kit](https://github.com/benjee10/Shuttle-Orbiter-Construction-Kit) to be fly with [DeadlyReentry](https://github.com/Starwaster/DeadlyReentry) and [RP-0](https://github.com/KSP-RO/RP-0).

The current shuttle forwardFuselage part will overheat and explode right after entering atmosphere, this profile provides extra heat tolerance for all surface parts.